### PR TITLE
Remove Plausible Analytics link to kaiwern.com

### DIFF
--- a/themes/my-theme/layouts/partials/head.html
+++ b/themes/my-theme/layouts/partials/head.html
@@ -22,7 +22,6 @@
 {{ else }}
   {{ $styles := $styles| minify | fingerprint | resources.PostProcess }}
   <link rel="stylesheet" href="{{ $styles.Permalink }}" integrity="{{ $styles.Data.Integrity }}">
-  <script async defer data-domain="kaiwern.com" src="https://plausible.io/js/plausible.js"></script>
 {{ end }}
 
 <link rel="preconnect" href="https://fonts.googleapis.com">


### PR DESCRIPTION
Hi, I have been getting analytics from your website since the theme contain a hardcoded Plausible Analytics script:
![Screenshot 2024-03-03 at 6 56 19 PM](https://github.com/zenuo/zenuo.github.io/assets/12683067/4e7b7320-73e7-41af-892c-85b5976248ce) 
![Screenshot 2024-03-03 at 6 56 24 PM](https://github.com/zenuo/zenuo.github.io/assets/12683067/cfb6638a-d992-43a4-b7d6-ba5f263920b8)

This PR is to remove the analytics link to my Plausible Analytics account. Thanks.